### PR TITLE
Uses end() instad of close()

### DIFF
--- a/streams/simple.php
+++ b/streams/simple.php
@@ -12,7 +12,7 @@ $loop->addPeriodicTimer(1, function(React\EventLoop\Timer\Timer $timer) use (&$i
 
     if ($i >= 15) {
         $loop->cancelTimer($timer);
-        $stream->close();
+        $stream->end();
     }
 });
 


### PR DESCRIPTION
I noticed that by doing $stream->close(); the last number (15) that we wrote to the stream wasn't being printed out in the stdout, and I figured out (looking into the code) it is because "close()" is more like a forced shutdown. Using $stream->end(); will allow the buffer to be emptied first, thus, allowing the last number to be written to the stdout.
I'm not implying the use of "close()" in the example is wrong, but, for me it just didn't yield the same result as the "echo"/"non-stream" example (which might be confusing/intriguing).
